### PR TITLE
Add response status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ void (async () => {
 interface Response {
   /** Whether the response was successful (status in the range 200-299) */
   ok: boolean;
+  /** Response status code */
+  statusCode: number;
   /** Response headers */
   headers: Record<string, string | string[]>;
   /** Return origin stream */

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,6 +128,8 @@ void (async () => {
 interface Response {
   /** Whether the response was successful (status in the range 200-299) */
   ok: boolean;
+  /** Response status code */
+  statusCode: number;
   /** Response headers */
   headers: Record<string, string | string[]>;
   /** Return origin stream */

--- a/src/Response/index.ts
+++ b/src/Response/index.ts
@@ -112,6 +112,12 @@ export default class implements Response {
     return statusCode >= 200 && statusCode < 300;
   }
 
+  /** Response status code */
+  get statusCode(): number {
+    const { statusCode } = this.config;
+    return statusCode;
+  }
+
   get headers() {
     return this.config.headers.raw();
   }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -112,6 +112,8 @@ export interface ValidateOptions {
 export interface Response {
   /** Whether the response was successful (status in the range 200-299) */
   ok: boolean;
+  /** Response status code */
+  statusCode: number;
   /** Response headers */
   headers: Record<string, string | string[]>;
   /** Return origin stream */


### PR DESCRIPTION
By providing the response status code it will be possible to understand why a request fails, hence developers can do a better error handling.